### PR TITLE
Fix Generator

### DIFF
--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -5,6 +5,7 @@ namespace Orchestra\Canvas\Core\Commands;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Orchestra\Canvas\Core\CodeGenerator;
+use Orchestra\Canvas\Core\TestGenerator;
 use Orchestra\Canvas\Core\Contracts\GeneratesCodeListener;
 use Orchestra\Canvas\Core\GeneratesCode;
 use Orchestra\Canvas\Core\Presets\Preset;


### PR DESCRIPTION
The Generator Command class does seem to use the TestGenerator trait but does not load it. This PR will add the missing use directive:
```php
use Orchestra\Canvas\Core\TestGenerator;
```

This will fix the following Error:
```
PHP Fatal error:  Trait "Orchestra\Canvas\Core\Commands\TestGenerator" not found in /var/www/html/modules/Test/vendor/orchestra/canvas-core/src/Commands/Generator.php on line 20
```