### PR TITLE
Fix TestGenerator trait

### DIFF
--- a/src/Commands/Generator.php
+++ b/src/Commands/Generator.php
@@ -202,7 +202,6 @@ abstract class Generator extends Command implements GeneratesCodeListener, Promp
     public function afterCodeHasBeenGenerated(string $className, string $path): void
     {
         if (\in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
-            /** @phpstan-ignore-next-line */
             $this->handleTestCreationUsingCanvas($path);
         }
     }

--- a/src/TestGenerator.php
+++ b/src/TestGenerator.php
@@ -2,6 +2,8 @@
 
 namespace Orchestra\Canvas\Core;
 
+use Illuminate\Support\Str;
+
 trait TestGenerator
 {
     /**
@@ -17,7 +19,7 @@ trait TestGenerator
         }
 
         return $this->callSilent('make:test', [
-            'name' => Str::of($path)->after($this->preset->sourcePath())->beforeLast('.php')->append('Test')->replace('\\', '/'),
+            'name'   => Str::of($path)->after($this->preset->sourcePath())->beforeLast('.php')->append('Test')->replace('\\', '/'),
             '--pest' => $this->option('pest'),
         ]) == 0;
     }


### PR DESCRIPTION
The TestGenerator trait does use \Illuminate\Support\Str but does not load it. This PR will add the missing use directive to load the String helper in the trait - this should also fix the *analyse* check.