### PR TITLE
[10.x] Update name of possibleModelsUsingCanvas() to align with new Laravel method name

### DIFF
--- a/src/Concerns/UsesGeneratorOverrides.php
+++ b/src/Concerns/UsesGeneratorOverrides.php
@@ -81,6 +81,19 @@ trait UsesGeneratorOverrides
     }
 
     /**
+     * Get a list of possible model names.
+     * 
+     * @return array<int, string>
+     * 
+     * @deprecated 10.1.0 Use `findAvailableModelsUsingCanvas()` instead.
+     */
+    #[\Deprecated('Use `findAvailableModelsUsingCanvas()` instead.', since: '10.1.0')]
+    protected function possibleModelsUsingCanvas(): array
+    {
+        return $this->findAvailableModelsUsingCanvas();
+    }
+
+    /**
      * Get a list of possible event names.
      *
      * @return array<int, string>

--- a/src/Concerns/UsesGeneratorOverrides.php
+++ b/src/Concerns/UsesGeneratorOverrides.php
@@ -67,7 +67,7 @@ trait UsesGeneratorOverrides
      *
      * @return array<int, string>
      */
-    protected function possibleModelsUsingCanvas(): array
+    protected function findAvailableModelsUsingCanvas(): array
     {
         $sourcePath = $this->generatorPreset()->sourcePath();
 

--- a/tests/Concerns/UsesGeneratorOverridesTest.php
+++ b/tests/Concerns/UsesGeneratorOverridesTest.php
@@ -71,7 +71,7 @@ class UsesGeneratorOverridesTestStub implements Arrayable
         return [
             'user-model' => $this->qualifyModelUsingCanvas('User'),
             'welcome-view' => $this->viewPathUsingCanvas('welcome.blade.php'),
-            'possible-models' => $this->possibleModelsUsingCanvas(),
+            'possible-models' => $this->findAvailableModelsUsingCanvas(),
             'possible-events' => $this->possibleEventsUsingCanvas(),
         ];
     }


### PR DESCRIPTION
Fixes upstream issue with a change in Laravel 12.38 that has broken TestBench installs due to an overriden protected method change. PR with explanation and issue here https://github.com/orchestral/canvas/pull/48